### PR TITLE
Use httplib to get CCAMS working on Linux (via Wine)

### DIFF
--- a/CCAMS.h
+++ b/CCAMS.h
@@ -18,11 +18,13 @@ using namespace EuroScopePlugIn;
 #else
 #define MY_PLUGIN_VERSION		"2.3.3"
 #endif
-#define MY_PLUGIN_VERSIONCODE	14
-#define MY_PLUGIN_UPDATE_URL	"https://raw.githubusercontent.com/kusterjs/CCAMS/master/config2.txt"
-//#define MY_PLUGIN_UPDATE_URL	"https://raw.githubusercontent.com/kusterjs/CCAMS/1.8/config.txt"
-#define MY_PLUGIN_DEVELOPER		"Jonas Kuster, Pierre Ferran, Oliver Grützmann"
-#define MY_PLUGIN_COPYRIGHT		"GPL v3"
+#define MY_PLUGIN_VERSIONCODE		14
+#define MY_PLUGIN_UPDATE_BASE		"https://raw.githubusercontent.com"
+#define MY_PLUGIN_UPDATE_ENDPOINT	"/kusterjs/CCAMS/master/config2.txt"
+#define MY_PLUGIN_APP_BASE			"https://ccams.kilojuliett.ch"
+#define MY_PLUGIN_APP_ENDPOINT		"/squawk"
+#define MY_PLUGIN_DEVELOPER			"Jonas Kuster, Pierre Ferran, Oliver Grï¿½tzmann"
+#define MY_PLUGIN_COPYRIGHT			"GPL v3"
 //#define MY_PLUGIN_VIEW      "Standard ES radar screen"
 
 struct ItemCodes

--- a/CCAMS.vcxproj
+++ b/CCAMS.vcxproj
@@ -40,6 +40,7 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
     <PreferredToolArchitecture>x86</PreferredToolArchitecture>
+    <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -55,7 +56,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
     <CodeAnalysisRuleSet>MixedRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -64,6 +64,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Static|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release-Static|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/CCMAS.sln
+++ b/CCMAS.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29424.173
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CCAMS", "CCAMS.vcxproj", "{26DEB76D-3967-4550-80CE-5C9DAAFAA1FC}"
 EndProject

--- a/Helpers.cpp
+++ b/Helpers.cpp
@@ -4,59 +4,23 @@
 string LoadUpdateString()
 {
 	const string AGENT{ "EuroScope " + (string)ESversion() + " plug-in: " + MY_PLUGIN_NAME + "/" + MY_PLUGIN_VERSION};
-	HINTERNET connect = InternetOpen(AGENT.c_str(), INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
-	if (!connect) {
-		throw error { string {"Connection failed to verify the plugin version. Error: " + to_string(GetLastError()) } };
+
+	/* NEW HTTPLIB Client implementation */
+	httplib::Client cli(MY_PLUGIN_UPDATE_BASE);
+	auto res = cli.Get(MY_PLUGIN_UPDATE_ENDPOINT);
+
+	if (!res || res->status != httplib::StatusCode::OK_200) {
+		auto err = res.error();
+		throw error{ string {"Connection failed to verify the plugin version. Error: " + httplib::to_string(err) } };
 	}
 
-	HINTERNET OpenAddress = InternetOpenUrl(connect, MY_PLUGIN_UPDATE_URL, NULL, 0, INTERNET_FLAG_PRAGMA_NOCACHE | INTERNET_FLAG_RELOAD, 0);
-	if (!OpenAddress) {
-		InternetCloseHandle(connect);
-		throw error { string { "Failed to load plugin version verification file. Error: " + to_string(GetLastError()) } };
-	}
+	std::string answer = res->body;
 
-	char DataReceived[256];
-	DWORD NumberOfBytesRead { 0 };
-	string answer;
-	while (InternetReadFile(OpenAddress, DataReceived, 256, &NumberOfBytesRead) && NumberOfBytesRead)
-		answer.append(DataReceived, NumberOfBytesRead);
-
-	InternetCloseHandle(OpenAddress);
-	InternetCloseHandle(connect);
 	return answer;
 }
 
 string LoadWebSquawk(EuroScopePlugIn::CFlightPlan FP, EuroScopePlugIn::CController ATCO, vector<const char*> usedCodes, bool vicinityADEP, int ConnectionType)
 {
-	//PluginData p;
-	//const string AGENT{ "EuroScope " + string { MY_PLUGIN_NAME } + "/" + string { MY_PLUGIN_VERSION } };
-	const string AGENT{ "EuroScope " + (string)ESversion() + " plug-in: " + MY_PLUGIN_NAME + "/" + MY_PLUGIN_VERSION };
-	HINTERNET connect = InternetOpen(AGENT.c_str(), INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
-	if (!connect) {
-#ifdef _DEBUG
-		//throw error { string { "Failed reach the CCAMS server. Error: " + to_string(GetLastError()) } };
-#endif
-		return string{ "E404" };
-	}
-
-	//int statusCode;
-	char responseText[MAX_PATH]; // change to wchar_t for unicode
-	DWORD responseTextSize = sizeof(responseText);
-
-	//Check existance of page (for 404 error)
-	if (HttpQueryInfo(connect, HTTP_QUERY_STATUS_CODE, &responseText, &responseTextSize, NULL))
-	{
-		//statusCode = ;
-		if (atoi(responseText) != 200)
-			return string{ "E" + string(responseText) };
-	}
-
-	//cpr::Response r = cpr::Get(cpr::Url{ "http://localhost/webtools/CCAMS/squawk" },
-	//	cpr::Parameters{ {"callsign", ATCO.GetCallsign()} });
-	//if (r.status_code != 200)
-	//	return "CURL ERROR";
-
-
 	string codes;
 	for (size_t i = 0; i < usedCodes.size(); i++)
 	{
@@ -65,54 +29,49 @@ string LoadWebSquawk(EuroScopePlugIn::CFlightPlan FP, EuroScopePlugIn::CControll
 		codes += usedCodes[i];
 	}
 
-	//string build_url = "http://localhost/webtools/CCAMS/squawk?callsign=" + string(ATCO.GetCallsign());
-	string build_url = "https://ccams.kilojuliett.ch/squawk?callsign=" + string(ATCO.GetCallsign());
+	string query_string = "callsign=" + string(ATCO.GetCallsign());
 	if (FP.IsValid())
 	{
 		if (vicinityADEP)
 		{
-			build_url += "&orig=" + string(FP.GetFlightPlanData().GetOrigin());
+			query_string += "&orig=" + string(FP.GetFlightPlanData().GetOrigin());
 		}
-		build_url += "&dest=" + string(FP.GetFlightPlanData().GetDestination()) +
+		query_string += "&dest=" + string(FP.GetFlightPlanData().GetDestination()) +
 			"&flightrule=" + string(FP.GetFlightPlanData().GetPlanType());
 
 		if (FP.GetCorrelatedRadarTarget().IsValid())
 			if (FP.GetCorrelatedRadarTarget().GetPosition().IsValid())
-				build_url += "&latitude=" + to_string(FP.GetCorrelatedRadarTarget().GetPosition().GetPosition().m_Latitude) +
+				query_string += "&latitude=" + to_string(FP.GetCorrelatedRadarTarget().GetPosition().GetPosition().m_Latitude) +
 					"&longitude=" + to_string(FP.GetCorrelatedRadarTarget().GetPosition().GetPosition().m_Longitude);
 
-		build_url += "&connectiontype=" + to_string(ConnectionType);
+		query_string += "&connectiontype=" + to_string(ConnectionType);
 
 #ifndef _DEBUG
 		if (ConnectionType > 2)
 		{
-			build_url += "&sim";
+			query_string += "&sim";
 		}
 #endif
 	}
 	if (codes.size() > 0)
 	{
-		build_url += "&codes=" + codes;
+		query_string += "&codes=" + codes;
 	}
 
-	HINTERNET OpenAddress = InternetOpenUrl(connect, build_url.c_str(), NULL, 0, INTERNET_FLAG_PRAGMA_NOCACHE | INTERNET_FLAG_RELOAD, 0);
-	if (!OpenAddress) {
-		InternetCloseHandle(connect);
-#ifdef _DEBUG
-		//throw error{ string { "Failed reach the CCAMS server. Error: " + to_string(GetLastError()) } };
-#endif
+	httplib::Headers headers = {
+		{"User-Agent", "EuroScope " + (string)ESversion() + " plug-in: " + MY_PLUGIN_NAME + "/" + MY_PLUGIN_VERSION }
+	};
 
-		return string{ "E406" };
+	httplib::Client client(MY_PLUGIN_APP_BASE);
+	std::string uri = MY_PLUGIN_APP_ENDPOINT + std::string("?") + query_string;
+	auto res = client.Get(uri, headers);
+
+	if (!res || res->status != httplib::StatusCode::OK_200) {
+		auto err = res.error();
+		return string{ httplib::to_string(err) };
 	}
 
-	char DataReceived[256];
-	DWORD NumberOfBytesRead{ 0 };
-	string answer;
-	while (InternetReadFile(OpenAddress, DataReceived, 256, &NumberOfBytesRead) && NumberOfBytesRead)
-		answer.append(DataReceived, NumberOfBytesRead);
-
-	InternetCloseHandle(OpenAddress);
-	InternetCloseHandle(connect);
+	std::string answer = res->body;
 
 	trim(answer);
 

--- a/Helpers.h
+++ b/Helpers.h
@@ -9,6 +9,9 @@
 #include <EuroScopePlugIn.h>
 #include "CCAMS.h"
 
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+#include <Windows.h>
 
 using namespace std;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": [
+    "openssl",
+    "cpp-httplib"
+  ]
+}


### PR DESCRIPTION
CCAMS was failing to do any HTTP call (right from the start at https://github.com/kusterjs/CCAMS/blob/2.3.1/Helpers.cpp#L12-L16)  when using with Euroscope on Linux via Wine, probably because of incompatiblity with Wine's `WinInet.h`

In order to fix this, I have replaced WinInet usage with `httplib` and brought in also `openssl` in order to support SSL/TLS, this increases the DLL size quite a lot unfortunately.

In order to bring in httplib and openssl in an easy way, I have added these external dependencies using `vcpkg`

I hope this PR can be useful, as this was (for me at least) the last missing link to properly do ATC from Linux (and still be compatible with Windows) 😄 