### PR TITLE
Attempt to reach ES 3.2.8 compatibility

### DIFF
--- a/CCAMS.cpp
+++ b/CCAMS.cpp
@@ -515,17 +515,15 @@ void CCAMS::AssignAutoSquawk(CFlightPlan& FlightPlan)
 			}
 			return;
 		}
-		else
-		{
-			// removing the call sign from the processed flight plan list to initiate a new assignment
-			ProcessedFlightPlans.erase(remove(ProcessedFlightPlans.begin(), ProcessedFlightPlans.end(), FlightPlan.GetCallsign()), ProcessedFlightPlans.end());
+
+		// removing the call sign from the processed flight plan list to initiate a new assignment
+		ProcessedFlightPlans.erase(remove(ProcessedFlightPlans.begin(), ProcessedFlightPlans.end(), FlightPlan.GetCallsign()), ProcessedFlightPlans.end());
 #ifdef _DEBUG
-			log << FlightPlan.GetCallsign() << ":FP removed from processed list:strip push received";
-			writeLogFile(log);
-			string DisplayMsg = string{ FlightPlan.GetCallsign() } + " removed from processed list because a strip push has been received";
-			DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
+		log << FlightPlan.GetCallsign() << ":duplicate assigned code:FP removed from processed list";
+		writeLogFile(log);
+		string DisplayMsg = string{ FlightPlan.GetCallsign() } + " removed from processed list because the assigned code is no longer valid";
+		DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
-		}
 	}
 
 	if (FlightPlan.GetSimulated() || strcmp(FlightPlan.GetFlightPlanData().GetPlanType(), "V") == 0)

--- a/CCAMS.cpp
+++ b/CCAMS.cpp
@@ -451,7 +451,7 @@ void CCAMS::OnTimer(int Counter)
 
 #ifdef _DEBUG
 	if (ConnectionStatus == 10)
-		DisplayUserMessage(MY_PLUGIN_NAME, "Debug", "Active connection establish, automatic squawk assignment enabled", true, false, false, false, false);
+		DisplayUserMessage(MY_PLUGIN_NAME, "Debug", "Active connection established, automatic squawk assignment enabled", true, false, false, false, false);
 #endif
 
 
@@ -1012,7 +1012,7 @@ bool CCAMS::HasValidSquawk(const EuroScopePlugIn::CFlightPlan& FlightPlan)
 			{
 				// duplicate identified for the actual set code
 #ifdef _DEBUG
-				DisplayMsg = "SET code '" + string{ assr } + "' of " + FlightPlan.GetCallsign() + " is already used by " + RadarTarget.GetCallsign();
+				DisplayMsg = "SET code '" + string{ pssr } + "' of " + FlightPlan.GetCallsign() + " is already used by " + RadarTarget.GetCallsign();
 				DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
 				return false;
@@ -1027,7 +1027,7 @@ bool CCAMS::HasValidSquawk(const EuroScopePlugIn::CFlightPlan& FlightPlan)
 	// no duplicate with assigend or used codes has been found
 #ifdef _DEBUG
 	DisplayMsg = "No duplicates found for " + string{ FlightPlan.GetCallsign() } + " (ASSIGNED '" + assr + "', SET code " + pssr + ")";
-	DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
+	//DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
 	return true;
 }

--- a/CCAMS.cpp
+++ b/CCAMS.cpp
@@ -534,25 +534,31 @@ void CCAMS::AssignAutoSquawk(CFlightPlan& FlightPlan)
 	{
 		// disregard simulated flight plans (out of the controllers range)
 		// disregard flight with flight rule VFR
-		ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
+		if (find(ProcessedFlightPlans.begin(), ProcessedFlightPlans.end(), FlightPlan.GetCallsign()) != ProcessedFlightPlans.end())
+		{
+			ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
 #ifdef _DEBUG
-		log << FlightPlan.GetCallsign() << ":FP processed:Simulated/FP Type";
-		writeLogFile(log);
-		DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed due to Simulation Flag / Flight Plan Type";
-		DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
+			log << FlightPlan.GetCallsign() << ":FP processed:Simulated/FP Type";
+			writeLogFile(log);
+			DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed due to Simulation Flag / Flight Plan Type";
+			DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
+		}
 		return;
 	}
 	else if (FlightPlan.GetFlightPlanData().IsReceived() && FlightPlan.GetSectorEntryMinutes() < 0)
 	{
 		// the flight will never enter the sector of the current controller
-		ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
+		if (find(ProcessedFlightPlans.begin(), ProcessedFlightPlans.end(), FlightPlan.GetCallsign()) != ProcessedFlightPlans.end())
+		{
+			ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
 #ifdef _DEBUG
-		log << FlightPlan.GetCallsign() << ":FP processed:Sector Entry Time:" << FlightPlan.GetSectorEntryMinutes();
-		writeLogFile(log);
-		DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed because it will not enter the controllers sector";
-		DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
+			log << FlightPlan.GetCallsign() << ":FP processed:Sector Entry Time:" << FlightPlan.GetSectorEntryMinutes();
+			writeLogFile(log);
+			DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed because it will not enter the controllers sector";
+			DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
+		}
 		return;
 	}
 	else if (HasValidSquawk(FlightPlan))
@@ -560,13 +566,16 @@ void CCAMS::AssignAutoSquawk(CFlightPlan& FlightPlan)
 		// this flight has already assigned a valid unique code
 		if (FlightPlan.GetTrackingControllerIsMe())
 		{
-			ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
+			{
+				if (find(ProcessedFlightPlans.begin(), ProcessedFlightPlans.end(), FlightPlan.GetCallsign()) != ProcessedFlightPlans.end())
+					ProcessedFlightPlans.push_back(FlightPlan.GetCallsign());
 #ifdef _DEBUG
-			log << FlightPlan.GetCallsign() << ":FP processed:has already a valid squawk:" << assr << ":" << pssr;
-			writeLogFile(log);
-			DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed because it has already a valid squawk (ASSIGNED '" + assr + "', SET " + pssr + ")";
-			DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
+				log << FlightPlan.GetCallsign() << ":FP processed:has already a valid squawk:" << assr << ":" << pssr;
+				writeLogFile(log);
+				DisplayMsg = string{ FlightPlan.GetCallsign() } + " processed because it has already a valid squawk (ASSIGNED '" + assr + "', SET " + pssr + ")";
+				DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
+			}
 		}
 		// if this flight is not tracked by the current controller yet, it is kept for revalidation in the next round
 
@@ -1003,7 +1012,7 @@ bool CCAMS::HasValidSquawk(const EuroScopePlugIn::CFlightPlan& FlightPlan)
 			{
 				// duplicate identified for the actual set code
 #ifdef _DEBUG
-				DisplayMsg = "SET code " + string{ assr } + " of " + FlightPlan.GetCallsign() + " is already used by " + RadarTarget.GetCallsign();
+				DisplayMsg = "SET code '" + string{ assr } + "' of " + FlightPlan.GetCallsign() + " is already used by " + RadarTarget.GetCallsign();
 				DisplayUserMessage(MY_PLUGIN_NAME, "Debug", DisplayMsg.c_str(), true, false, false, false, false);
 #endif
 				return false;

--- a/CCAMS.h
+++ b/CCAMS.h
@@ -14,7 +14,7 @@ using namespace EuroScopePlugIn;
 
 #define MY_PLUGIN_NAME			"CCAMS"
 #ifdef _DEBUG
-#define MY_PLUGIN_VERSION		"2.3.5 DEV"
+#define MY_PLUGIN_VERSION		"2.3.6 DEV"
 #else
 #define MY_PLUGIN_VERSION		"2.3.3"
 #endif

--- a/CCAMS.h
+++ b/CCAMS.h
@@ -14,7 +14,7 @@ using namespace EuroScopePlugIn;
 
 #define MY_PLUGIN_NAME			"CCAMS"
 #ifdef _DEBUG
-#define MY_PLUGIN_VERSION		"2.3.6 DEV"
+#define MY_PLUGIN_VERSION		"2.3.7 DEV"
 #else
 #define MY_PLUGIN_VERSION		"2.3.3"
 #endif
@@ -109,6 +109,7 @@ private:
 	bool pluginVersionCheck;
 	bool acceptEquipmentICAO;
 	bool acceptEquipmentFAA;
+	bool updateOnStartTracking;
 	bool autoAssign;
 	int APTcodeMaxGS;
 	int APTcodeMaxDist;

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This plugin provides capabilities/functionalities to:
 * ```.help ccams``` provides a list of all available plugin commands
 * ```.ccams ehslist``` displays the Mode S EHS list
 * ```.ccams auto``` enables/disables automatic transponder code assignment for IFR airborne aircraft
+* ```.ccams tracking``` enables/disables transponder code validation when starting to track a flight
 * ```.ccams reload``` reloads local (refer to plugin settings) and remote (mode S capability and plugin version) config data
 
 ### Plugin settings


### PR DESCRIPTION
Attempt to reach ES 3.2.8 compatibility no successful, however a few other improvements and developments were done
improvement of automatic squawk assignment to increase efficiency (reduce the number of unnecessary checks), but keep a monitoring for duplicates
option added to deactivate the transponder code verification upon starting to track an aircraft