### PR TITLE
Fix typo in LoadWebSquawk helper

### DIFF
--- a/Helpers.cpp
+++ b/Helpers.cpp
@@ -55,7 +55,7 @@ string LoadWebSquawk(EuroScopePlugIn::CFlightPlan FP, EuroScopePlugIn::CControll
 	for (size_t i = 0; i < usedCodes.size(); i++)
 	{
 		if (i > 0)
-			codes += "~";
+			codes += ",";
 		codes += usedCodes[i];
 	}
 


### PR DESCRIPTION
There was a small typo in the concatenation of the `codes` variable: a `~` was used instead of a `,`